### PR TITLE
Fix screenshot Dockerfile and Playwright for Docker containers.

### DIFF
--- a/docker/screenshot/Dockerfile
+++ b/docker/screenshot/Dockerfile
@@ -1,12 +1,12 @@
-FROM alpine:3.20.2 AS linux
-RUN apk add openjdk17 
+FROM gradle:8.10.0-jdk17-alpine AS base
+FROM mcr.microsoft.com/playwright/java:jammy-amd64 as playwright
 
-FROM openjdk:17-slim AS builder
+FROM base AS builder
 WORKDIR /appHome
 COPY . .
-RUN ./gradlew assemble
+RUN gradle assemble
 
-FROM linux AS runner
+FROM playwright 
 WORKDIR /app
 COPY --from=builder /appHome/app/build/libs/app.jar screenshot.jar
 COPY scripts/ scripts/

--- a/screenshot/.gitignore
+++ b/screenshot/.gitignore
@@ -5,3 +5,4 @@
 build
 
 app/*.png
+app/screenshots

--- a/screenshot/scripts/entrypoint.sh
+++ b/screenshot/scripts/entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec java screenshot.jar -Dfindfirst.screenshot.location=/app/screenshots
+exec java -jar screenshot.jar -Dfindfirst.screenshot.location=/app/screenshots


### PR DESCRIPTION
- When the developer ran the container and curl with an url, playwright would not be able to download the drivers. REST call would fail.

- When developer built the container with docker compose build screenshot the screenshot.jar would not be found. Fixed in the docker/screenshot/Dockerfile.