### PR TITLE
ENV and SQL column sizes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       dockerfile: ../docker/frontend/Dockerfile
       context: ./frontend
+      args:
+        BUILDENV: dev
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
- Part of the problem was already solved. The second problem was that the docker compose didn't specify the build type, and it would result to prod.