### PR TITLE
feat(issue-224): update AddBkmkReq to include scrapable

### DIFF
--- a/server/src/main/java/dev/findfirst/core/model/AddBkmkReq.java
+++ b/server/src/main/java/dev/findfirst/core/model/AddBkmkReq.java
@@ -2,5 +2,5 @@ package dev.findfirst.core.model;
 
 import java.util.List;
 
-public record AddBkmkReq(String title, String url, List<Long> tagIds) {
+public record AddBkmkReq(String title, String url, List<Long> tagIds, boolean scrapable) {
 }

--- a/server/src/main/java/dev/findfirst/core/service/BookmarkService.java
+++ b/server/src/main/java/dev/findfirst/core/service/BookmarkService.java
@@ -204,7 +204,7 @@ public class BookmarkService {
         if (!url.equals("") || url == null) {
           title = (title.equals("") || title == null) ? url : title;
           log.debug("Bookmark contains: \n\t{},\n\t{}", title, url);
-          return addBookmark(new AddBkmkReq(title, url, null));
+          return addBookmark(new AddBkmkReq(title, url, null, true));
         }
       } catch (IOException | BookmarkAlreadyExistsException | TagNotFoundException ex) {
         log.error(ex.getMessage());


### PR DESCRIPTION
Issue number: #224 

---

## Checklist

- [ ] Code Formatter (run prettier/spotlessApply)
- [x] Code has unit tests? (If no explain in _other_information_)
- [x] Builds on localhost
- [x] Builds/Runs in docker compose

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

The `AddBkmkReq` record does not contain a boolean field named `scrapable`.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The new boolean field `scrapable` has been added to the `AddBkmkReq` record, with the default value set to `true` as discussed in issue #223. Additionally, the `BookmarkControllerTest` class has been updated to ensure the tests run successfully.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Looks like whenever I run `./gradlew spotlessApply` it fails due to the `DisableTenantFilter` annotation class checked by the `removeUnusedImports()` method in the `build.gradle` file for the server directory. Worth looking into.