### PR TITLE
bugfix: Update Spotless to ver 6.19.0

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'org.springframework.boot' version '3.3.2'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id "org.sonarqube" version "4.4.1.3373"
-  id "com.diffplug.spotless" version "6.11.0"
+  id "com.diffplug.spotless" version "6.19.0"
   id "org.flywaydb.flyway" version "10.1.0"
   id 'java'
   id 'jacoco'


### PR DESCRIPTION
Issue number: resolves #240

The recommended .gradlew spotlessApply functionality failed for dev environments running on JDK 21. This fix resolves the issue by updating the version of Spotless to 6.19.0, which seemingly fixes the compatibility issue with the aforementioned JDK version.

---

## Checklist

- [ ] Code Formatter (run prettier/spotlessApply)
- [ ] Code has unit tests? (If no explain in _other_information_)
- [x] Builds on localhost
- [x] Builds/Runs in docker compose

## What is the current behavior?
`./gradlew spotlessApply` fails for JDK version < 21. 

## What is the new behavior?
`./gradlew spotlessApply` works after updating the version 6.19.0.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
N/A
