### PR TITLE
Implement robots.txt check before scraping

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -85,6 +85,7 @@ dependencies {
   implementation 'org.flywaydb:flyway-core:10.17.1'
   // https://mvnrepository.com/artifact/org.springframework.data/spring-data-jdbc
   implementation 'org.springframework.data:spring-data-jdbc:3.3.4'
+  implementation group: 'com.github.crawler-commons', name: 'crawler-commons', version: '1.4'
 
   runtimeOnly "org.flywaydb:flyway-database-postgresql:10.1.0"
   runtimeOnly 'org.postgresql:postgresql:42.7.3'

--- a/server/src/main/java/dev/findfirst/core/model/RobotAgent.java
+++ b/server/src/main/java/dev/findfirst/core/model/RobotAgent.java
@@ -1,5 +1,0 @@
-package dev.findfirst.core.model;
-
-public record RobotAgent(String agent, boolean isAllowed, String path) {
-
-}

--- a/server/src/main/java/dev/findfirst/core/service/BookmarkService.java
+++ b/server/src/main/java/dev/findfirst/core/service/BookmarkService.java
@@ -10,15 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Service;
-import reactor.core.publisher.Flux;
-
 import jakarta.validation.constraints.NotNull;
 
 import dev.findfirst.core.exceptions.BookmarkAlreadyExistsException;
@@ -30,6 +21,15 @@ import dev.findfirst.core.model.Tag;
 import dev.findfirst.core.model.TagBookmarks;
 import dev.findfirst.core.repository.BookmarkRepository;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -38,6 +38,8 @@ public class BookmarkService {
   private final BookmarkRepository bookmarkRepository;
 
   private final TagService tagService;
+
+  private final WebCheckService webCheckService;
 
   private final ScreenshotManager sManager;
 
@@ -67,12 +69,13 @@ public class BookmarkService {
     String title = "";
     var optUrl = Optional.<String>empty();
 
-    if (reqBkmk.scrapable()) {
+    if (reqBkmk.scrapable() && webCheckService.isScrapable(reqBkmk.url())) {
       log.debug("Scrapable: true.\tScrapping URL and taking screenshot.");
 
       try {
         retDoc = Jsoup.connect(reqBkmk.url()).get();
-        log.debug("Response: {}\tTitle: {}", retDoc.connection().response().statusMessage(), retDoc.title());
+        log.debug("Response: {}\tTitle: {}", retDoc.connection().response().statusMessage(),
+            retDoc.title());
         title = !retDoc.title().isEmpty() ? retDoc.title() : reqBkmk.title();
 
       } catch (IOException e) {

--- a/server/src/main/java/dev/findfirst/core/service/RobotsFetcher.java
+++ b/server/src/main/java/dev/findfirst/core/service/RobotsFetcher.java
@@ -1,0 +1,39 @@
+package dev.findfirst.core.service;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class RobotsFetcher {
+
+  public RobotsTxtResponse getRobotsTxt(String url) {
+
+    try {
+      URL urlObj = new URI(url).toURL();
+      URL robotsUrl =
+          new URL(urlObj.getProtocol(), urlObj.getHost(), urlObj.getPort(), "/robots.txt");
+      HttpURLConnection conn = (HttpURLConnection) robotsUrl.openConnection();
+      conn.setRequestMethod("GET");
+      conn.setConnectTimeout(2000);
+      conn.setReadTimeout(2000);
+      int statusCode = conn.getResponseCode();
+      byte[] robotsContent = conn.getInputStream().readAllBytes();
+      String contentType = conn.getContentType();
+      conn.disconnect();
+      return new RobotsTxtResponse(statusCode, robotsContent, contentType);
+
+    } catch (URISyntaxException | IOException ex) {
+      log.error(ex.toString());
+      return new RobotsTxtResponse(500, "".getBytes(), "");
+    }
+  }
+
+  public record RobotsTxtResponse(int statusCode, byte[] text, String contentType) {}
+}

--- a/server/src/main/java/dev/findfirst/core/service/WebCheckService.java
+++ b/server/src/main/java/dev/findfirst/core/service/WebCheckService.java
@@ -1,54 +1,35 @@
 package dev.findfirst.core.service;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import dev.findfirst.core.model.RobotAgent;
+import dev.findfirst.core.service.RobotsFetcher.RobotsTxtResponse;
 
+import crawlercommons.robots.SimpleRobotRules;
+import crawlercommons.robots.SimpleRobotRulesParser;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
 
 @Service
 public class WebCheckService {
 
+  private final RobotsFetcher robotsFetcher;
+
+  public WebCheckService(@Autowired RobotsFetcher robotsFetcher) {
+    this.robotsFetcher = robotsFetcher;
+  }
+
   // Find out whether the robots.txt file of a website allows scraping
   public boolean isScrapable(String url) {
-
-    // call getRobotsTxt (return true for status code 404 and false for 5XX and other 4XX codes)
-    // call parseRobots
-    // if RobotAgent list empty, return true
-    // call findMostSpecificAgent
-    // check Allow/Disallow of the found agent
-
-    return true;
+    RobotsTxtResponse robotsTxtResponse = robotsFetcher.getRobotsTxt(url);
+    SimpleRobotRulesParser parser = new SimpleRobotRulesParser();
+    SimpleRobotRules rules;
+    if (robotsTxtResponse.statusCode() >= 400 && robotsTxtResponse.statusCode() <= 599) {
+      rules = parser.failedFetch(robotsTxtResponse.statusCode());
+    } else {
+      rules = parser.parseContent(url, robotsTxtResponse.text(), robotsTxtResponse.contentType(),
+          List.of());
+    }
+    return rules.isAllowed(url);
   }
-
-  // returns a RobotsTxtResponse so that isScrapable can deal with different status codes
-  private RobotsTxtResponse getRobotsTxt(String url) {
-
-    // issue a GET request to [DOMAIN]/robots.txt
-
-    return new RobotsTxtResponse(200, "");
-  }
-
-  private List<RobotAgent> parseRobots(String robotsTxt) {
-
-    // create entries for every line that can be parsed
-
-    return new ArrayList<>();
-  }
-
-  private RobotAgent findMostSpecificAgent(String url, List<RobotAgent> agents) {
-
-    RobotAgent currentMostSpecific = new RobotAgent("*", true, "");
-
-    /*
-     * iterate through all entries (skip entries with a user-agent other than '*') and check if they
-     * are more specific than the current one
-     */
-
-    return currentMostSpecific;
-  }
-
-
-  private record RobotsTxtResponse(int statusCode, String text) {}
 }

--- a/server/src/main/java/dev/findfirst/core/service/WebCheckService.java
+++ b/server/src/main/java/dev/findfirst/core/service/WebCheckService.java
@@ -50,14 +50,5 @@ public class WebCheckService {
   }
 
 
-  private class RobotsTxtResponse {
-
-    final private int statusCode;
-    final private String text;
-
-    private RobotsTxtResponse(int statusCode, String text) {
-      this.statusCode = statusCode;
-      this.text = text;
-    }
-  }
+  private record RobotsTxtResponse(int statusCode, String text) {}
 }

--- a/server/src/test/java/dev/findfirst/core/service/WebCheckServiceTest.java
+++ b/server/src/test/java/dev/findfirst/core/service/WebCheckServiceTest.java
@@ -1,35 +1,56 @@
 package dev.findfirst.core.service;
 
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 
+import static org.mockito.ArgumentMatchers.anyString;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
 public class WebCheckServiceTest {
 
+  @MockBean
+  RobotsFetcher robotsFetcher;
+
+  @Autowired
   WebCheckService webCheckService;
 
-  public WebCheckServiceTest() {
-    webCheckService = new WebCheckService();
-  }
 
   @Test
   public void isScrapable() {
-    Assertions.assertNull(null);
-  }
+    String robotsString = """
+        User-agent: *
+        Allow: /api/v*/store
+        Allow: /api/v*/applications
+        Allow: /api/v*/application-directory-static
+        Allow: /api/v*/invite
+        Allow: /api/v*/discovery
+        Allow: /api/discovery
+        Allow: /invite
+        Allow: /invite/
+        Allow: /terms
+        Allow: /privacy
+        Disallow: /channels
+        Disallow: /channels/
+        Disallow: /verify
+        Disallow: /verify/
+        """;
 
-  @Test
-  public void getRobotsTxt() {
-    Assertions.assertNull(null);
-  }
 
-  @Test
-  public void parseRobots() {
-    Assertions.assertNull(null);
-  }
+    Mockito.when(robotsFetcher.getRobotsTxt(anyString())).thenReturn(
+        new RobotsFetcher.RobotsTxtResponse(200, robotsString.getBytes(), "text/plain"));
 
-  @Test
-  public void findMostSpecificAgent() {
-    Assertions.assertNull(null);
+    Assertions.assertTrue(webCheckService.isScrapable("https://discord.com/api/discovery"));
+    Assertions.assertTrue(webCheckService.isScrapable("https://discord.com/invite/test.txt"));
+    Assertions.assertTrue(webCheckService.isScrapable("https://discord.com/api/vrevef/invite"));
+    Assertions.assertFalse(webCheckService.isScrapable("https://discord.com/channels"));
   }
-
 
 }


### PR DESCRIPTION
Issue number: resolves #236 

---

## Checklist

- [x] Code Formatter (run prettier/spotlessApply)
- [x] Code has unit tests? (If no explain in _other_information_)
- [x] Builds on localhost
- [x] Builds/Runs in docker compose


## What is the current behavior?

On bookmark creation, it tried to scrape no matter what (as long as the client has 'scrapable' toggled on (which is the default as of now)

## What is the new behavior?

- Check the robots.txt file
- Use the Google procedure to parse it and find out whether the URL is scrapable

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

"Google follows at least five redirect hops as defined by [RFC 1945](https://www.ietf.org/rfc/rfc1945.txt) and then stops and treats it as a 404 for the robots.txt. This also applies to any disallowed URLs in the redirect chain, since the crawler couldn't fetch rules due to the redirects." (https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt)

--> If you want to, you can make an issue to implement this too.
