### PR TITLE
feat: Decode Screenshot URI using URLDecoder

### DIFF
--- a/screenshot/app/src/main/java/dev/findfirst/screenshot/controller/ScreenshotController.java
+++ b/screenshot/app/src/main/java/dev/findfirst/screenshot/controller/ScreenshotController.java
@@ -10,6 +10,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
 @RestController
@@ -33,23 +36,29 @@ public class ScreenshotController {
     try (Playwright playwright = Playwright.create()) {
       // Use Chromium for this example; you can choose another browser type
       BrowserType browserType = playwright.chromium();
+
       try (Browser browser = browserType.launch()) {
         BrowserContext context = browser.newContext();
         Page page = context.newPage();
         page.navigate(url);
+
+        url = URLDecoder.decode(url, StandardCharsets.UTF_8);
         String cleanUrl = url.replaceAll("http[s]://", "").replace("/", "_");
+
         Path filePath = Path.of(screenshotSaveLoc, cleanUrl + ".png");
         page.screenshot(new Page.ScreenshotOptions().setPath(filePath));
+
         return filePath.getFileName().toString();
       }
     } catch (PlaywrightException e) {
       // Handle Playwright specific exceptions
       log.error("Error taking screenshot: " + e.getMessage());
       return null;
+
     } catch (Exception e) {
       // Handle other exceptions
       log.error("An unexpected error occurred: " + e.getMessage());
-      return null; 
+      return null;
     }
   }
 }


### PR DESCRIPTION
Issue number: resolves #235 

This resolves the issue when the spaces in the URIs are replaced with "%20", whereas it should be replaced with the ASCII space character instead. This is achieved by decoding the URL properly, before replacing the slashes.

---

## Checklist

- [x] Code Formatter (run prettier/spotlessApply)
- [ ] Code has unit tests? (If no explain in _other_information_)
- [x] Builds on localhost
- [x] Builds/Runs in docker compose

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
Screenshot URIs might contain "%20" instead of actual spaces

<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
URL Decoder is used to ensure that ASCII spaces appear in the URI, instead of "%20".

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
N/A
