### PR TITLE
Added Scheduled Job for adding missing screenshot urls of scrapable bookmarks

### DIFF
--- a/server/src/main/java/dev/findfirst/FindFirstApplication.java
+++ b/server/src/main/java/dev/findfirst/FindFirstApplication.java
@@ -10,12 +10,14 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.ApplicationContextException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
 @SpringBootApplication
 @Slf4j
+@EnableScheduling
 public class FindFirstApplication {
 
   public static void main(String[] args) {

--- a/server/src/main/java/dev/findfirst/core/repository/BookmarkRepository.java
+++ b/server/src/main/java/dev/findfirst/core/repository/BookmarkRepository.java
@@ -16,4 +16,7 @@ public interface BookmarkRepository extends TenantableRepository<Bookmark> {
   List<Bookmark> findByTag(Tag tag);
 
   Optional<Bookmark> findByUrl(String url);
+
+  @Query("SELECT b FROM Bookmark b WHERE b.screenshotUrl IS NULL OR TRIM(b.screenshotUrl)=''")
+  List<Bookmark> findBookmarksWithEmptyOrBlankScreenShotUrl();
 }

--- a/server/src/main/java/dev/findfirst/security/userAuth/tenant/aspects/TenantAspect.java
+++ b/server/src/main/java/dev/findfirst/security/userAuth/tenant/aspects/TenantAspect.java
@@ -1,24 +1,34 @@
 package dev.findfirst.security.userAuth.tenant.aspects;
 
+import java.util.Collections;
+
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
 import dev.findfirst.core.annotations.DisableTenantFilter;
+import dev.findfirst.security.jwt.TenantAuthenticationToken;
 import dev.findfirst.security.userAuth.tenant.contexts.TenantContext;
+import dev.findfirst.security.userAuth.tenant.listeners.TenantEntityListener;
 import dev.findfirst.security.userAuth.utils.Constants;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.hibernate.Session;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Aspect
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class TenantAspect {
 
   private final TenantContext tenantContext;
@@ -30,11 +40,37 @@ public class TenantAspect {
   public void beforeFindOfTenantableRepository(JoinPoint joinPoint) {
     entityManager.unwrap(Session.class).disableFilter(Constants.TENANT_FILTER_NAME);
     MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
-
+    // Enable Tenant Filter only if the method do not have DisableTenantFilter and context user is
+    // not super user with id -1000
     if (AnnotationUtils.getAnnotation(methodSignature.getMethod(),
-        DisableTenantFilter.class) == null || tenantContext.getTenantId() == -1000) {
+        DisableTenantFilter.class) == null
+        && tenantContext.getTenantId() != Constants.SUPERUSER_ID) {
       entityManager.unwrap(Session.class).enableFilter(Constants.TENANT_FILTER_NAME)
           .setParameter(Constants.TENANT_PARAMETER_NAME, tenantContext.getTenantId());
     }
   }
+
+  @Before("@annotation(org.springframework.scheduling.annotation.Scheduled)")
+  public void setSecurityContextBeforeScheduledTask() {
+    // Disable TenantEntityListener which updates tenant_id for entities.
+    TenantEntityListener.disableListener();
+    log.info("Setting Security context before scheduled task");
+    var simpleGrantedAuthority = new SimpleGrantedAuthority("admin");
+    var grantedAuthList = Collections.singletonList(simpleGrantedAuthority);
+    TenantAuthenticationToken tenantAuthenticationToken = new TenantAuthenticationToken(
+        "admin@findfirst.dev", 2, grantedAuthList, Constants.SUPERUSER_ID);
+    SecurityContextHolder.getContext().setAuthentication(tenantAuthenticationToken);
+    // Adding function that will run after transaction is completed.
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      log.info("Setting listener to clear security context after scheduled task");
+      TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        @Override
+        public void afterCompletion(int status) {
+          SecurityContextHolder.clearContext();
+          TenantEntityListener.enableListener();
+        }
+      });
+    }
+  }
+
 }

--- a/server/src/main/java/dev/findfirst/security/userAuth/tenant/listeners/TenantEntityListener.java
+++ b/server/src/main/java/dev/findfirst/security/userAuth/tenant/listeners/TenantEntityListener.java
@@ -1,5 +1,6 @@
 package dev.findfirst.security.userAuth.tenant.listeners;
 
+
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreRemove;
@@ -18,6 +19,8 @@ public class TenantEntityListener {
   @PrePersist
   @PreUpdate
   public void prePersistAndUpdate(Object object) {
+    if (!isListenerEnabled.get())
+      return;
     if (object instanceof Tenantable) {
       ((Tenantable) object).setTenantId(tenantContext.getTenantId());
     }
@@ -25,9 +28,21 @@ public class TenantEntityListener {
 
   @PreRemove
   public void preRemove(Object object) {
+    if (!isListenerEnabled.get())
+      return;
     if (object instanceof Tenantable
         && ((Tenantable) object).getTenantId() != tenantContext.getTenantId()) {
       throw new EntityNotFoundException();
     }
+  }
+
+  private static final ThreadLocal<Boolean> isListenerEnabled = ThreadLocal.withInitial(() -> true);
+
+  public static void disableListener() {
+    isListenerEnabled.set(false);
+  }
+
+  public static void enableListener() {
+    isListenerEnabled.set(true);
   }
 }

--- a/server/src/main/java/dev/findfirst/security/userAuth/utils/Constants.java
+++ b/server/src/main/java/dev/findfirst/security/userAuth/utils/Constants.java
@@ -15,4 +15,6 @@ public class Constants {
   public static final String MODERATOR_ROLE = "ROLE_MODERATOR";
   public static final String ADMIN_ROLE_NAME = "ROLE_ADMIN";
   public static final String USER_ROLE_NAME = "ROLE_USER";
+
+  public static final int SUPERUSER_ID = -1000;
 }

--- a/server/src/test/java/dev/findfirst/core/service/BookmarkServiceTest.java
+++ b/server/src/test/java/dev/findfirst/core/service/BookmarkServiceTest.java
@@ -1,0 +1,63 @@
+package dev.findfirst.core.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import dev.findfirst.core.model.Bookmark;
+import dev.findfirst.core.repository.BookmarkRepository;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookmarkServiceTest {
+
+  @InjectMocks
+  private BookmarkService bookmarkService;
+  @Mock
+  private BookmarkRepository bookmarkRepository;
+  @Mock
+  private ScreenshotManager sManager;
+
+  /**
+   * Tests that addMissingScreenShotUrlToBookMarks method of BookmarkService class add screenshots
+   * urls to scrapable bookmarks.
+   * 
+   * @param scrapable
+   */
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(booleans = {true, false})
+  void addMissingScreenShotUrlToBookMarksTests(Boolean scrapable) {
+    String screenshot_url = "http://example.com/3";
+    Bookmark bookmark = new Bookmark();
+    bookmark.setScrapable(scrapable);
+    List<Bookmark> list = new ArrayList<>();
+    list.add(bookmark);
+    if (Boolean.TRUE.equals(scrapable)) {
+      when(sManager.getScreenshot(any())).thenReturn(Optional.of(screenshot_url));
+      when(bookmarkRepository.saveAll(any())).thenReturn(list);
+    }
+    when(bookmarkRepository.findBookmarksWithEmptyOrBlankScreenShotUrl()).thenReturn(list);
+    bookmarkService.addMissingScreenShotUrlToBookMarks();
+    if (Boolean.TRUE.equals(scrapable)) {
+      Assertions.assertEquals(screenshot_url, bookmark.getScreenshotUrl(), "URL is not updated");
+      verify(sManager, times(1)).getScreenshot(any());
+    } else {
+      Assertions.assertNull(bookmark.getScreenshotUrl(), "URL is updated");
+      verify(sManager, never()).getScreenshot(any());
+    }
+    verify(bookmarkRepository, times(1)).findBookmarksWithEmptyOrBlankScreenShotUrl();
+    verify(bookmarkRepository, times(1)).saveAll(list);
+  }
+}


### PR DESCRIPTION
Issue number: resolves #173 

---

## Checklist

- [x] Code Formatter (run prettier/spotlessApply)
- [x] Code has unit tests? (If no explain in _other_information_)
- [x] Builds on localhost
- [x] Builds/Runs in docker compose

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- A method to fetch bookmarks with empty or null screenshot_urls is added in bookmark repository
- Added scheduled job in bookmark service which fetches the list of bookmarks having missing urls and if the bookmark is scrapable the screenshot_url is generated and stored in bookmark.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  5. Update the BREAKING.md file with the breaking change.
  6. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- Added methods to TenantAspect class to run before methods annotated with @Scheduled annotation. The aspect methods perform following tasks.:
   1. Add authentication in security context with SUPERUSER.
   2. Disable TenantEntityListner.
   3.  Add callback function to clear security context and enable TenantEntityListner after current transaction is completed.
- Added methods to enable and disable TenantEntityListner and added logic to do nothing in preupdate, prepersist, preremove methods if TenantEntityListner is disabled.
- Modified logic to enable TenantFilter base on SUPERUSER_ID in tenant context.
- Enabled Scheduling by adding @EnableScheduling annotation in FindFirstApplication class


