### PR TITLE
Issue 226 bookmark already exist error

### DIFF
--- a/frontend/api/Api.ts
+++ b/frontend/api/Api.ts
@@ -36,6 +36,8 @@ instance.interceptors.response.use(
       }
       failCount++;
       api.refreshToken(user!.refreshToken);
+    } else if(error.response.status === 409){
+      return {error: error.response.status};
     }
   },
 );

--- a/frontend/components/Bookmark/NewBookmarkCard.tsx
+++ b/frontend/components/Bookmark/NewBookmarkCard.tsx
@@ -16,6 +16,8 @@ import {
   NewBookmarkForm,
   newcard,
 } from "@type/Bookmarks/NewBookmark";
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 async function makeNewBookmark(createBmk: Bookmark): Promise<Bookmark> {
   let newBkmkRequest: NewBookmarkRequest;
@@ -36,6 +38,20 @@ async function makeNewBookmark(createBmk: Bookmark): Promise<Bookmark> {
     });
   });
   await api.addBookmark(newBkmkRequest).then((response) => {
+    console.log("API Response:", response);
+    if (response.error && response.error === 409){
+      console.log("Bookmark already exist")
+      toast.error('This Bookmark already exist !', {
+        position: "bottom-right",
+        autoClose: 5000,
+        hideProgressBar: false,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+        progress: undefined,
+        theme: "colored",
+        });
+    }
     createBmk.id = response.data.id;
     createBmk.tags = response.data.tags;
     createBmk.screenshotUrl = response.data.screenshotUrl;
@@ -251,6 +267,7 @@ export default function NewBookmarkCard() {
           </Form>
         )}
       </Formik>
+      <ToastContainer />
     </div>
   );
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "react": "18.3.1",
     "react-bootstrap": "^2.10.4",
     "react-dom": "18.3.1",
+    "react-toastify": "^10.0.6",
     "rxjs": "^7.8.1",
     "sass": "^1.77.8",
     "tailwind": "^4.0.0",

--- a/server/src/main/java/dev/findfirst/core/controller/BookmarkController.java
+++ b/server/src/main/java/dev/findfirst/core/controller/BookmarkController.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.Size;
 import dev.findfirst.core.dto.AddBkmkReq;
 import dev.findfirst.core.dto.BookmarkDTO;
 import dev.findfirst.core.dto.TagDTO;
+import dev.findfirst.core.exceptions.BookmarkAlreadyExistsException;
 import dev.findfirst.core.model.jdbc.BookmarkTag;
 import dev.findfirst.core.service.BookmarkService;
 import dev.findfirst.core.service.TagService;
@@ -78,6 +79,9 @@ public class BookmarkController {
     try {
       BookmarkDTO createdBookmark = bookmarkService.addBookmark(req);
       return response.setResponse(createdBookmark, HttpStatus.OK);
+    } catch (BookmarkAlreadyExistsException e) {
+      // Return 409 Conflict if the bookmark already exists
+      return response.setResponse(HttpStatus.CONFLICT);
     } catch (Exception e) {
       e.printStackTrace();
       return response.setResponse(HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
Issue number: resolves #

---

## Checklist

- [ ] Code Formatter (run prettier/spotlessApply)
- [ ] Code has unit tests? (If no explain in _other_information_)
- [ ] Builds on localhost
- [ ] Builds/Runs in docker compose

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
For the backend, I use an already existing exception, BookmarkAlreadyExistsException, to handle cases where a bookmark already exists. This exception triggers a 409 Conflict HTTP response.

On the frontend, I catch the Conflict (409) error and use react-toastify to display a toast notification in the bottom-right corner of the screen, informing the user about the conflict that Bookmark already exist.

<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
