### PR TITLE
Configured global exception handler with RestControllerAdvice

### DIFF
--- a/server/src/main/java/dev/findfirst/core/controller/BookmarkController.java
+++ b/server/src/main/java/dev/findfirst/core/controller/BookmarkController.java
@@ -13,7 +13,6 @@ import jakarta.validation.constraints.Size;
 import dev.findfirst.core.dto.AddBkmkReq;
 import dev.findfirst.core.dto.BookmarkDTO;
 import dev.findfirst.core.dto.TagDTO;
-import dev.findfirst.core.exceptions.BookmarkAlreadyExistsException;
 import dev.findfirst.core.exceptions.BookmarkNotFoundException;
 import dev.findfirst.core.exceptions.TagNotFoundException;
 import dev.findfirst.core.model.jdbc.BookmarkTag;
@@ -82,13 +81,8 @@ public class BookmarkController {
   public ResponseEntity<BookmarkDTO> addBookmark(@RequestBody AddBkmkReq req)
       throws TagNotFoundException, URISyntaxException {
     var response = new Response<BookmarkDTO>();
-    try {
-      BookmarkDTO createdBookmark = bookmarkService.addBookmark(req);
-      return response.setResponse(createdBookmark, HttpStatus.OK);
-    } catch (BookmarkAlreadyExistsException e) {
-      // Return 409 Conflict if the bookmark already exists
-      return response.setResponse(HttpStatus.CONFLICT);
-    }
+    BookmarkDTO createdBookmark = bookmarkService.addBookmark(req);
+    return response.setResponse(createdBookmark, HttpStatus.OK);
   }
 
   @DeleteMapping(value = "/bookmark", produces = "application/json")

--- a/server/src/main/java/dev/findfirst/core/exceptions/BookmarkAlreadyExistsException.java
+++ b/server/src/main/java/dev/findfirst/core/exceptions/BookmarkAlreadyExistsException.java
@@ -1,7 +1,9 @@
 package dev.findfirst.core.exceptions;
 
-public class BookmarkAlreadyExistsException extends Exception {
-  public BookmarkAlreadyExistsException() {
-    super("Bookmark already exists with the same data.");
+import org.springframework.http.HttpStatus;
+
+public class BookmarkAlreadyExistsException extends ErrorResponseException {
+  public BookmarkAlreadyExistsException(String logMessage) {
+    super(HttpStatus.CONFLICT, "Bookmark already exists.", logMessage);
   }
 }

--- a/server/src/main/java/dev/findfirst/core/exceptions/ErrorResponseException.java
+++ b/server/src/main/java/dev/findfirst/core/exceptions/ErrorResponseException.java
@@ -1,0 +1,22 @@
+package dev.findfirst.core.exceptions;
+
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@Getter
+public class ErrorResponseException extends ResponseStatusException {
+  private final String serverLogMessage;
+
+  public ErrorResponseException(HttpStatus code, String reason, String serverLogMessage) {
+    super(code, reason);
+    this.serverLogMessage = serverLogMessage;
+  }
+
+  public ErrorResponseException(HttpStatus code, String reason, String serverLogMessage,
+      Throwable cause) {
+    super(code, reason, cause);
+    this.serverLogMessage = serverLogMessage;
+  }
+}

--- a/server/src/main/java/dev/findfirst/core/exceptions/GlobalExceptionHandler.java
+++ b/server/src/main/java/dev/findfirst/core/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package dev.findfirst.core.exceptions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+  // Handles ResponseStatusException and its child classes
+  @ExceptionHandler(value = {ResponseStatusException.class})
+  protected ResponseEntity<Map<String, String>> handleResponseStatusException(
+      ResponseStatusException ex) {
+    // Extract log message
+    String logMessage =
+        ex instanceof ErrorResponseException ? ((ErrorResponseException) ex).getServerLogMessage()
+            : ex.getReason();
+    StackTraceElement[] stackTrace = ex.getStackTrace();
+    // Get the first relevant stack trace element (usually the point where the exception was thrown)
+    StackTraceElement origin = stackTrace.length > 0 ? stackTrace[0] : null;
+    if (origin != null) {
+      log.error("ResponseStatusException occurred at {}.{} ({}:{}) - Reason: {}",
+          origin.getClassName(), origin.getMethodName(), origin.getFileName(),
+          origin.getLineNumber(), logMessage);
+    } else {
+      log.error("ResponseStatusException occurred - Reason: {}", logMessage);
+    }
+
+    // Prepare body
+    Map<String, String> error = new HashMap<>();
+    error.put("error", ex.getReason());
+    return new ResponseEntity<>(error, ex.getStatusCode());
+  }
+}

--- a/server/src/main/java/dev/findfirst/core/service/BookmarkService.java
+++ b/server/src/main/java/dev/findfirst/core/service/BookmarkService.java
@@ -119,11 +119,13 @@ public class BookmarkService {
   }
 
   public BookmarkDTO addBookmark(AddBkmkReq reqBkmk)
-      throws BookmarkAlreadyExistsException, TagNotFoundException, URISyntaxException {
+      throws TagNotFoundException, URISyntaxException {
     var tags = new ArrayList<Long>();
 
     if (bookmarkJDBCRepository.findByUrl(reqBkmk.url(), uContext.getUserId()).isPresent()) {
-      throw new BookmarkAlreadyExistsException();
+      String logMessage = "Bookmark already exists for user with id " + uContext.getUserId()
+          + " and url: " + reqBkmk.url();
+      throw new BookmarkAlreadyExistsException(logMessage);
     }
 
     if (reqBkmk.tagIds() != null) {

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -26,3 +26,7 @@ findfirst.local.screenshot=../data/screenshots
 findfirst.screenshot.location=${FINDFIRST_SCREENSHOT_LOCATION:${findfirst.local.screenshot}}
 findfirst.app.frontend-url=${FINDFIRST_APP_FRONTEND-URL:http://localhost:3000/}
 findfirst.app.domain=localhost
+
+# ERROR HANDLING
+# https://docs.spring.io/spring-boot/api/java/org/springframework/boot/autoconfigure/web/ErrorProperties.IncludeStacktrace.html
+server.error.include-stacktrace=never

--- a/server/src/test/java/dev/findfirst/core/controller/BookmarkControllerTest.java
+++ b/server/src/test/java/dev/findfirst/core/controller/BookmarkControllerTest.java
@@ -9,10 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import dev.findfirst.core.annotations.IntegrationTest;
 import dev.findfirst.core.dto.AddBkmkReq;
@@ -351,8 +348,9 @@ class BookmarkControllerTest {
     saveBookmarks(new AddBkmkReq("search", "https://bing.com", new ArrayList<>(), true));
     var ent = getHttpEntity(restTemplate,
         new AddBkmkReq("search", "https://bing.com", new ArrayList<>(), true));
-    var blResp = restTemplate.exchange(bookmarkURI, HttpMethod.POST, ent, BookmarkDTO[].class);
+    var blResp = restTemplate.exchange(bookmarkURI, HttpMethod.POST, ent, Map.class);
     assertEquals(HttpStatus.CONFLICT, blResp.getStatusCode());
+    assertEquals("Bookmark already exists.", (blResp.getBody()).get("error"));
   }
 
   @Test


### PR DESCRIPTION
Issue number: resolves #98

---

## Checklist

- [x] Code Formatter (run prettier/spotlessApply)
- [ ] Code has unit tests? (If no explain in _other_information_)
- [x] Builds on localhost
- [x] Builds/Runs in docker compose

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
1. For any exception thrown full stack trace is sent to client.
2. On server side every exception needs to be handled separately.

## What is the new behavior?
1. No stack trace will be sent to client in case of exception.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  3. Update the BREAKING.md file with the breaking change.
  4. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->

## Other information
1. Global Exception handler is configured in file GlobalExceptionHandler.java which handles logging for error also.
2. Added ErrorResponseException class it will be good to extend any further exception class from this class for handling exception globally.
3. One of the test triggerBookmarkAlreadyExistException from BookmarkControllerTest.java tests the newly added global exception handler.