### PR TITLE
Replace createServerKeys.sh

### DIFF
--- a/server/scripts/entrypoint.sh
+++ b/server/scripts/entrypoint.sh
@@ -1,4 +1,3 @@
 #! /bin/sh
 mkdir keys
-./scripts/createServerKeys.sh /app/keys
 exec java -Djwt.private.key=file:/app/keys/app.key  -Djwt.public.key=file:/app/keys/app.pub -jar findfirst.jar

--- a/server/src/main/java/dev/findfirst/FindFirstApplication.java
+++ b/server/src/main/java/dev/findfirst/FindFirstApplication.java
@@ -1,7 +1,11 @@
 package dev.findfirst;
 
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collections;
+
+import dev.findfirst.security.util.KeyGenerator;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
@@ -22,8 +26,9 @@ public class FindFirstApplication {
 
   public static void main(String[] args) {
     try {
+      KeyGenerator.generateKeys("app.key", "app.pub");
       SpringApplication.run(FindFirstApplication.class, args);
-    } catch (ApplicationContextException ude) {
+    } catch (ApplicationContextException | NoSuchAlgorithmException | IOException ude) {
       log.error("""
 
 

--- a/server/src/main/java/dev/findfirst/security/util/KeyGenerator.java
+++ b/server/src/main/java/dev/findfirst/security/util/KeyGenerator.java
@@ -1,0 +1,55 @@
+package dev.findfirst.security.util;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
+public class KeyGenerator {
+
+  public static void generateKeys(String privateKeyPath, String publicKeyPath)
+      throws NoSuchAlgorithmException, IOException {
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    keyGen.initialize(2048);
+    KeyPair pair = keyGen.generateKeyPair();
+    PrivateKey privateKey = pair.getPrivate();
+    PublicKey publicKey = pair.getPublic();
+
+    // Save the private key in PKCS8 format
+    PKCS8EncodedKeySpec pkcs8EncodedKeySpec = new PKCS8EncodedKeySpec(privateKey.getEncoded());
+    try (FileOutputStream fos = new FileOutputStream(privateKeyPath)) {
+      fos.write(pkcs8EncodedKeySpec.getEncoded());
+    }
+
+    // Save the public key in X.509 format
+    X509EncodedKeySpec x509EncodedKeySpec = new X509EncodedKeySpec(publicKey.getEncoded());
+    try (FileOutputStream fos = new FileOutputStream(publicKeyPath)) {
+      fos.write(x509EncodedKeySpec.getEncoded());
+    }
+  }
+
+  public static void main(String[] args) {
+    String privateKeyPath = "app.key";
+    String publicKeyPath = "app.pub";
+
+    File privateKeyFile = new File(privateKeyPath);
+    File publicKeyFile = new File(publicKeyPath);
+
+    if (!privateKeyFile.exists() || !publicKeyFile.exists()) {
+      try {
+        generateKeys(privateKeyPath, publicKeyPath);
+        System.out.println("Keys generated successfully.");
+      } catch (NoSuchAlgorithmException | IOException e) {
+        e.printStackTrace();
+      }
+    } else {
+      System.out.println("Keys already exist.");
+    }
+  }
+}


### PR DESCRIPTION
Issue number: resolves #313

---

## Checklist

- [ ] Code Formatter (run prettier/spotlessApply)
- [ ] Code has unit tests? (If no explain in _other_information_)
- [ ] Builds on localhost
- [x] Builds/Runs in docker compose

## What is the current behavior?

createServerKeys script is used for the generation of Keys during authentication.

## What is the new behavior?

Now the generation of the keys is done in the server side, all done by creating a Java version of the createServerKeys script

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

entrypoint.sh new look:
<img width="867" alt="Screenshot 2025-01-23 at 11 27 32 a m" src="https://github.com/user-attachments/assets/bec1a1e5-4cb1-40e1-a013-a559ab9ef4c9" />


Main Class for the FindFirstApplication class look:
<img width="731" alt="Screenshot 2025-01-23 at 11 29 08 a m" src="https://github.com/user-attachments/assets/b70d92ab-3871-42f3-9bd9-8d4f965e7428" />

Key Generator Java Class look:
<img width="702" alt="Screenshot 2025-01-23 at 11 34 42 a m" src="https://github.com/user-attachments/assets/288b609b-57d0-44cd-afb4-f2d609775f59" />


