### PR TITLE
feat: scrap for each Oauth2 providers favicon

### DIFF
--- a/server/src/main/java/dev/findfirst/users/service/Oauth2SourceService.java
+++ b/server/src/main/java/dev/findfirst/users/service/Oauth2SourceService.java
@@ -1,0 +1,76 @@
+package dev.findfirst.users.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+
+import dev.findfirst.users.model.oauth2.Oauth2Source;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class Oauth2SourceService {
+
+  private InMemoryClientRegistrationRepository oauth2Providers;
+
+  private final List<Oauth2Source> oauth2Sources = new ArrayList<>();
+
+  @PostConstruct
+  void init() {
+    oauth2Providers.iterator().forEachRemaining(provider -> {
+      var tknUri = provider.getProviderDetails().getTokenUri();
+      log.debug("Token URI {}", tknUri);
+      // skip http(s)://
+      if (!tknUri.contains("https://")) {
+        log.debug("provider without https {}", tknUri);
+        // do we really want to trust anything that isn't https?
+        return;
+      }
+      oauth2Sources.add(new Oauth2Source(provider.getClientName(), getFaviconURI(provider),
+          "oauth2/authorization/" + provider.getRegistrationId()));
+    });
+  }
+
+  public List<Oauth2Source> oauth2Sources() {
+    return oauth2Sources;
+  }
+
+  @Autowired(required = false)
+  public void setOauth2Providers(InMemoryClientRegistrationRepository oauth2Providers) {
+    this.oauth2Providers = oauth2Providers;
+  }
+
+  private String getFaviconURI(ClientRegistration provider) {
+    var targetUri = provider.getProviderDetails().getAuthorizationUri();
+    log.debug("Scraping {} for favicon URI", targetUri);
+    try {
+      Element link = Jsoup.connect(targetUri).userAgent("Mozilla").get().head()
+          .select("link[href~=.*\\.(ico|png)]").first();
+
+      if (link == null) {
+        log.debug("No favicon URI found at {}", targetUri);
+        return null;
+      }
+
+      String href = link.attr("href");
+      log.debug("Found favicon URI: {}", href);
+      return href;
+    } catch (IOException e) {
+      log.error("Failed to scrape {}", targetUri, e);
+      return null;
+    }
+
+  }
+
+}

--- a/server/src/test/java/dev/findfirst/users/service/Oauth2SourceServiceTest.java
+++ b/server/src/test/java/dev/findfirst/users/service/Oauth2SourceServiceTest.java
@@ -1,0 +1,136 @@
+package dev.findfirst.users.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.List;
+
+import dev.findfirst.users.model.oauth2.Oauth2Source;
+
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+class Oauth2SourceServiceTest {
+
+  private Oauth2SourceService service;
+
+  private ClientRegistration provider;
+
+  @BeforeEach
+  void setUp() {
+    provider = ClientRegistration.withRegistrationId("test").clientName("Test Provider")
+        .authorizationUri("https://www.example-auth.com")
+        .authorizationGrantType(AuthorizationGrantType.JWT_BEARER)
+        .tokenUri("https://www.example.com").build();
+    var providers = new InMemoryClientRegistrationRepository(List.of(provider));
+    service = new Oauth2SourceService();
+    service.setOauth2Providers(providers);
+  }
+
+  @Test
+  void testReturnsOauth2SourcesWithIconUrl_WhenFoundedAtWebsite() throws IOException {
+    try (MockedStatic<Jsoup> jsoupMock = mockStatic(Jsoup.class)) {
+      Connection mockConnection = mock(Connection.class);
+      Document mockDoc = mock(Document.class);
+      Element mockElement = mock(Element.class);
+      Elements mockElements = mock(Elements.class);
+
+      when(mockConnection.userAgent(anyString())).thenReturn(mockConnection);
+      when(mockConnection.get()).thenReturn(mockDoc);
+      when(mockDoc.head()).thenReturn(mockElement);
+      when(mockElement.select(anyString())).thenReturn(mockElements);
+      when(mockElements.first()).thenReturn(mockElement);
+      when(mockElement.attr("href")).thenReturn("https://example.com/assets/favicon.ico");
+      jsoupMock.when(() -> Jsoup.connect(anyString())).thenReturn(mockConnection);
+
+      service.init();
+
+      List<Oauth2Source> oauth2Sources = service.oauth2Sources();
+
+      assertFalse(oauth2Sources.isEmpty());
+      var oauth2Source = oauth2Sources.getFirst();
+      assertEquals(provider.getClientName(), oauth2Source.provider());
+      assertEquals("https://example.com/assets/favicon.ico", oauth2Source.iconUrl());
+      assertEquals("oauth2/authorization/" + provider.getRegistrationId(),
+          oauth2Source.authEndpoint());
+
+
+    }
+  }
+
+  @Test
+  void testReturnsOauth2SourcesWithoutIconUrl_WhenNotFoundedAtWebsite() throws IOException {
+    try (MockedStatic<Jsoup> jsoupMock = mockStatic(Jsoup.class)) {
+      Connection mockConnection = mock(Connection.class);
+      Document mockDoc = mock(Document.class);
+      Element mockElement = mock(Element.class);
+      Elements mockElements = mock(Elements.class);
+
+      when(mockConnection.userAgent(anyString())).thenReturn(mockConnection);
+      when(mockConnection.get()).thenReturn(mockDoc);
+      when(mockDoc.head()).thenReturn(mockElement);
+      when(mockElement.select(anyString())).thenReturn(mockElements);
+      when(mockElements.first()).thenReturn(null);
+      jsoupMock.when(() -> Jsoup.connect(anyString())).thenReturn(mockConnection);
+
+      service.init();
+
+      List<Oauth2Source> oauth2Sources = service.oauth2Sources();
+
+      assertFalse(oauth2Sources.isEmpty());
+      var oauth2Source = oauth2Sources.getFirst();
+      assertEquals(provider.getClientName(), oauth2Source.provider());
+      assertNull(oauth2Source.iconUrl());
+      assertEquals("oauth2/authorization/" + provider.getRegistrationId(),
+          oauth2Source.authEndpoint());
+
+
+    }
+  }
+
+  @Test
+  void testReturnsOauth2SourcesWithoutIconUrl_WhenNotConnectedAtWebsite() throws IOException {
+    try (MockedStatic<Jsoup> jsoupMock = mockStatic(Jsoup.class)) {
+      Connection mockConnection = mock(Connection.class);
+      when(mockConnection.userAgent(anyString())).thenReturn(mockConnection);
+      when(mockConnection.get()).thenThrow(IOException.class);
+
+      jsoupMock.when(() -> Jsoup.connect(anyString())).thenReturn(mockConnection);
+
+      service.init();
+
+      List<Oauth2Source> oauth2Sources = service.oauth2Sources();
+
+      assertFalse(oauth2Sources.isEmpty());
+      var oauth2Source = oauth2Sources.getFirst();
+      assertEquals(provider.getClientName(), oauth2Source.provider());
+      assertNull(oauth2Source.iconUrl());
+      assertEquals("oauth2/authorization/" + provider.getRegistrationId(),
+          oauth2Source.authEndpoint());
+
+    }
+  }
+
+  @Test
+  void testReturnsOauth2SourcesWithoutUntrustedTokenUri() {
+    provider = ClientRegistration.withRegistrationId("test").clientName("Test Provider")
+        .authorizationUri("https://www.example-auth.com")
+        .authorizationGrantType(AuthorizationGrantType.JWT_BEARER)
+        .tokenUri("http://www.example.com").build();
+    var providersWithoutSSL = new InMemoryClientRegistrationRepository(List.of(provider));
+    service.setOauth2Providers(providersWithoutSSL);
+    service.init();
+    assertTrue(service.oauth2Sources().isEmpty());
+
+  }
+}


### PR DESCRIPTION
Issue number: resolves #376 

---

## Checklist

- [x] Code Formatter (run prettier/spotlessApply)
- [x] Code has unit tests? (If no explain in _other_information_)
- [x] Builds on localhost
- [x] Builds/Runs in docker compose

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->
Currently, the application returns a list of OAuth2 providers with a default favicon URL, which does not work for some providers.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now, the application scrapes the favicon from the provider's authorization URI using Jsoup.
- The application also uses a @Service that is loaded at Spring Boot startup and scrapes the favicon only once.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Before:

<img width="1915" height="754" alt="image" src="https://github.com/user-attachments/assets/405b755f-6866-4bc7-9e71-95887515bafd" />

After:

<img width="1907" height="774" alt="image" src="https://github.com/user-attachments/assets/0dcdb832-dd25-4794-bb7e-434b6e0856a8" />


