### PR TITLE
fix: add 'untagged' tag to bookmarks without tags on creation

### DIFF
--- a/frontend/components/Bookmark/BookmarkCard.tsx
+++ b/frontend/components/Bookmark/BookmarkCard.tsx
@@ -136,9 +136,12 @@ export default function BookmarkCard({ bookmark }: Readonly<BookmarkProp>) {
   useEffect(() => {
     if (bookmark) {
       const tagList: string[] = [];
-      bookmark.tags.forEach((tag: Tag) => {
-        tagList.push(tag.title);
-      });
+      if (bookmark.tags.length == 0) tagList.push("untagged");
+      else {
+        bookmark.tags.forEach((tag: Tag) => {
+          tagList.push(tag.title);
+        });
+      }
       setStrTags(tagList);
     }
   }, [bookmark]);
@@ -211,7 +214,11 @@ export default function BookmarkCard({ bookmark }: Readonly<BookmarkProp>) {
       );
     }
     api.deleteTagById(bookmark.id, tagId);
-    let titles = currentBookmark.current.tags.map((t) => t.title); // just the titles display
+    // if there are no tags to display, display "untagged", else display the tags for the bookmark
+    let titles =
+      currentBookmark.current.tags.length !== 0
+        ? currentBookmark.current.tags.map((t) => t.title)
+        : ["untagged"]; // just the titles display
     setStrTags(titles);
 
     // update the sidebar.
@@ -227,7 +234,10 @@ export default function BookmarkCard({ bookmark }: Readonly<BookmarkProp>) {
   const onPushTag = (tag: string) =>
     addTagToBookmark(bookmark, tag).then((action) => {
       dispatch(action);
-      setStrTags([...strTags, tag]);
+      setStrTags((prev) => {
+        const cleaned = prev.filter((t) => t != "untagged");
+        return [...cleaned, tag];
+      });
       currentBookmark.current.tags.push({ id: action.id, title: action.title });
     });
 

--- a/frontend/components/Bookmark/BookmarkCard.tsx
+++ b/frontend/components/Bookmark/BookmarkCard.tsx
@@ -7,7 +7,7 @@ import DeleteModal from "./DeleteModal";
 import style from "./bookmarkCard.module.scss";
 import { useBookmarkDispatch } from "@/contexts/BookmarkContext";
 import BookmarkAction from "@/types/Bookmarks/BookmarkAction";
-import Tag from "@/types/Bookmarks/Tag";
+import Tag, { UNTAGGED } from "@/types/Bookmarks/Tag";
 import api from "@/api/Api";
 import CardBody from "./CardBody";
 import { SERVER_URL } from "@type/global";
@@ -136,12 +136,9 @@ export default function BookmarkCard({ bookmark }: Readonly<BookmarkProp>) {
   useEffect(() => {
     if (bookmark) {
       const tagList: string[] = [];
-      if (bookmark.tags.length == 0) tagList.push("untagged");
-      else {
-        bookmark.tags.forEach((tag: Tag) => {
-          tagList.push(tag.title);
-        });
-      }
+      bookmark.tags.forEach((tag: Tag) => {
+        tagList.push(tag.title);
+      });
       setStrTags(tagList);
     }
   }, [bookmark]);
@@ -206,19 +203,15 @@ export default function BookmarkCard({ bookmark }: Readonly<BookmarkProp>) {
     });
   }
 
-  const onDeleteTag = (idx: number) => {
-    const tagId = bookmark.tags[idx].id;
+  const onDeleteTag = (t: string) => {
+    const tagId = bookmark.tags.find(st => st.title === t)?.id!;
     if (currentBookmark.current) {
       currentBookmark.current.tags = currentBookmark.current.tags.filter(
-        (_t, i) => i !== idx,
+        (bt, i) => bt.id !== tagId,
       );
     }
     api.deleteTagById(bookmark.id, tagId);
-    // if there are no tags to display, display "untagged", else display the tags for the bookmark
-    let titles =
-      currentBookmark.current.tags.length !== 0
-        ? currentBookmark.current.tags.map((t) => t.title)
-        : ["untagged"]; // just the titles display
+    let titles = currentBookmark.current.tags.map((t) => t.title); // just the titles display
     setStrTags(titles);
 
     // update the sidebar.
@@ -229,26 +222,39 @@ export default function BookmarkCard({ bookmark }: Readonly<BookmarkProp>) {
       bookmark,
     };
     dispatch(action);
+
+    if (titles) {
+      let action: TagAction = {
+        type: "add",
+        id: -1,
+        title: "",
+        bookmark,
+      };
+      dispatch(action);
+
+    }
   };
 
   const onPushTag = (tag: string) =>
     addTagToBookmark(bookmark, tag).then((action) => {
       dispatch(action);
-      setStrTags((prev) => {
-        const cleaned = prev.filter((t) => t != "untagged");
-        return [...cleaned, tag];
-      });
-      currentBookmark.current.tags.push({ id: action.id, title: action.title });
+      if (strTags.length === 0) {
+        let action: TagAction = {
+          type: "delete",
+          id: -1,
+          title: UNTAGGED,
+          bookmark,
+        };
+        dispatch(action);
+
+      }
+      setStrTags([...strTags, tag]);
     });
 
   function getIdxFromTitle(title: string): number {
     return bookmark.tags.findIndex((t) => t.title == title);
   }
 
-  const onChange = (e: any) => {
-    const { value } = e.target;
-    setInput(value);
-  };
 
   function Content(): ReactNode {
     return bookmark.screenshotUrl ? (

--- a/frontend/components/Bookmark/NewBookmarkCard.tsx
+++ b/frontend/components/Bookmark/NewBookmarkCard.tsx
@@ -104,7 +104,7 @@ export default function NewBookmarkCard() {
 
   const handleOnSubmit = async (
     submittedBmk: NewBookmarkForm,
-    actions: any,
+    actions: any
   ) => {
     // Get the last inputted string and all the tags already entered.
     let tags: Tag[] = strTags.map((t) => ({ title: t, id: -1 }));
@@ -112,6 +112,12 @@ export default function NewBookmarkCard() {
       // FIXME
       tags.push({ title: tagInput, id: -1 });
     }
+
+    // Add default "untagged" tag if user has not provided any
+    if (!tags.length) {
+      tags = [{ title: "untagged", id: -1 }];
+    }
+
     let newBkmk: Bookmark = {
       id: -1,
       title: submittedBmk.title || submittedBmk.url,

--- a/frontend/components/Bookmark/NewBookmarkCard.tsx
+++ b/frontend/components/Bookmark/NewBookmarkCard.tsx
@@ -104,18 +104,13 @@ export default function NewBookmarkCard() {
 
   const handleOnSubmit = async (
     submittedBmk: NewBookmarkForm,
-    actions: any
+    actions: any,
   ) => {
     // Get the last inputted string and all the tags already entered.
     let tags: Tag[] = strTags.map((t) => ({ title: t, id: -1 }));
     if (tagInput) {
       // FIXME
       tags.push({ title: tagInput, id: -1 });
-    }
-
-    // Add default "untagged" tag if user has not provided any
-    if (!tags.length) {
-      tags = [{ title: "untagged", id: -1 }];
     }
 
     let newBkmk: Bookmark = {

--- a/frontend/components/Bookmark/TagInput.tsx
+++ b/frontend/components/Bookmark/TagInput.tsx
@@ -5,7 +5,7 @@ const TagInput = (props: {
   tags: readonly string[];
   inputValue: string;
   setInputValue: (val: string) => void;
-  onDeleteTag: (index: number) => void;
+  onDeleteTag: (index: string) => void;
   onPushTag: (tag: string) => void;
   testIdPrefix: `bk-${string}-` | `new-bk-`;
 }) => {
@@ -28,7 +28,7 @@ const TagInput = (props: {
       const tagsCopy = [...props.tags];
       const poppedTag = tagsCopy.pop();
       if (poppedTag) {
-        props.onDeleteTag(props.tags.length - 1);
+        props.onDeleteTag(poppedTag);
         props.setInputValue(poppedTag);
       }
     }
@@ -39,10 +39,10 @@ const TagInput = (props: {
       {props.tags.map((tag, index) => (
         <button
           key={tag}
-          onClick={() => props.onDeleteTag(index)}
+          onClick={() => props.onDeleteTag(tag)}
           onContextMenu={(e) => {
             e.preventDefault();
-            props.onDeleteTag(index);
+            props.onDeleteTag(tag);
           }}
           type="button"
           className={style.pillButton}

--- a/frontend/components/CardView/BookmarkCardsView.tsx
+++ b/frontend/components/CardView/BookmarkCardsView.tsx
@@ -6,14 +6,6 @@ import { useTags } from "@/contexts/TagContext";
 import { TagWithCnt } from "@type/Bookmarks/Tag";
 import cardView from "styles/cardView.module.scss";
 
-function getTagId(map: Map<number, TagWithCnt>, tagTitle: string) {
-  for (let [k, v] of map) {
-    if (v.title === tagTitle) {
-      return k;
-    }
-  }
-  return -1;
-}
 
 // Bookmark group composed of Bookmarks.
 export default function BookmarkCardsView() {
@@ -35,12 +27,9 @@ export default function BookmarkCardsView() {
     } else {
       selected.forEach((selectedTag) => {
         // get tagId of each selected
-        const key = getTagId(tags, selectedTag);
-        if (key > 0) {
-          const selectedBkmks = tags.get(key)?.associatedBkmks.map((v) => v.id);
-          if (selectedBkmks) {
-            addIfNotInList(selectedBkmks);
-          }
+        const selectedBkmks = tags.get(selectedTag)?.associatedBkmks.map((v) => v.id);
+        if (selectedBkmks) {
+          addIfNotInList(selectedBkmks);
         }
       });
       return [...filterMap.values()];

--- a/frontend/components/Tags/TagList.tsx
+++ b/frontend/components/Tags/TagList.tsx
@@ -9,12 +9,19 @@ import itemStyle from "./tag-list-item.module.scss";
 import menuStyle from "styles/tag.module.scss";
 import { useSelectedTags } from "@/contexts/SelectedContext";
 import { useScreenSize } from "@/contexts/ScreenSizeContext";
+import { useBookmarks } from "@/contexts/BookmarkContext"; // import bookmarks for the "untagged" tag
+
 const TagList = () => {
   const userAuth = useAuth();
   const tagMap = useTags();
   const [loading, setLoading] = useState(false);
   const { selected, setSelected } = useSelectedTags();
   const isPC = useScreenSize();
+  const bookmark = useBookmarks();
+  // check if at least one bookmark has no tags
+  const hasUntaggedBookmark = bookmark.fetchedBookmarks.some(
+    (t) => t.tags.length === 0,
+  );
   useEffect(() => {
     if (userAuth && tagMap.size == 0) {
       setLoading(true);
@@ -51,6 +58,22 @@ const TagList = () => {
   }
 
   let groupItems: any = [];
+  // adds "untagged" tag to the tag list
+  if (hasUntaggedBookmark) {
+    groupItems.push(
+      <ListGroup.Item key={"untagged-item"} className={`${itemStyle.item}`}>
+        <button
+          onClick={(event) => selectTag(event, "untagged")}
+          className={`d-flex btn ${itemStyle.btn} justify-content-between align-items-start`}
+        >
+          untagged
+          <Badge bg="primary" pill>
+            {bookmark.fetchedBookmarks.filter((b) => b.tags.length == 0).length}
+          </Badge>
+        </button>
+      </ListGroup.Item>,
+    );
+  }
   tagMap.forEach((tagCnt) => {
     groupItems.push(
       <ListGroup.Item

--- a/frontend/components/Tags/TagList.tsx
+++ b/frontend/components/Tags/TagList.tsx
@@ -4,12 +4,12 @@ import { Badge, ListGroup } from "react-bootstrap";
 import { useTags } from "@/contexts/TagContext";
 import useAuth from "@components/UseAuth";
 import api from "@/api/Api";
-import { TagReqPayload, TagWithCnt } from "@/types/Bookmarks/Tag";
+import { TagReqPayload, TagWithCnt, UNTAGGED } from "@/types/Bookmarks/Tag";
 import itemStyle from "./tag-list-item.module.scss";
 import menuStyle from "styles/tag.module.scss";
 import { useSelectedTags } from "@/contexts/SelectedContext";
 import { useScreenSize } from "@/contexts/ScreenSizeContext";
-import { useBookmarks } from "@/contexts/BookmarkContext"; // import bookmarks for the "untagged" tag
+import { useBookmarks } from "@/contexts/BookmarkContext";
 
 const TagList = () => {
   const userAuth = useAuth();
@@ -22,15 +22,15 @@ const TagList = () => {
   const hasUntaggedBookmark = bookmark.fetchedBookmarks.some(
     (t) => t.tags.length === 0,
   );
-  useEffect(() => {
-    if (userAuth && tagMap.size == 0) {
-      setLoading(true);
-      api
-        .getAllTags()
+
+  const noTags = bookmark.fetchedBookmarks.filter(b => b.tags.length === 0); useEffect(() => {
+    if (userAuth && tagMap.size == 0 && !bookmark.loading) {
+      setLoading(true); api.getAllTags()
         .then((results) => {
           const tags: TagReqPayload[] = results.data as TagReqPayload[];
           for (let tag of tags) {
             const twc: TagWithCnt = {
+              id: tag.id,
               title: tag.title,
               count: tag.bookmarks.length,
               associatedBkmks: tag.bookmarks,
@@ -41,63 +41,60 @@ const TagList = () => {
         .then(() => {
           setLoading(false);
         });
+      if (hasUntaggedBookmark) {
+        const untaggeds: TagWithCnt = {
+          id: -1,
+          title: UNTAGGED,
+          count: noTags.length,
+          associatedBkmks: noTags,
+        };
+        tagMap.set(-1, untaggeds);
+      }
     }
-  }, [tagMap, userAuth]);
 
-  function selectTag(event: any, title: string) {
-    const idx = selected.indexOf(title);
+  }, [tagMap, userAuth, hasUntaggedBookmark, bookmark.loading]);
+
+  function selectTag(event: any, id: number) {
+    const idx = selected.indexOf(id);
     if (idx >= 0) {
       const updated = [...selected];
       updated.splice(idx, 1);
       setSelected(updated);
       event.target.classList.remove(itemStyle.on);
     } else {
-      setSelected([...selected, title]);
+      setSelected([...selected, id]);
       event.target.classList.add(itemStyle.on);
     }
   }
 
   let groupItems: any = [];
-  // adds "untagged" tag to the tag list
-  if (hasUntaggedBookmark) {
-    groupItems.push(
-      <ListGroup.Item key={"untagged-item"} className={`${itemStyle.item}`}>
-        <button
-          onClick={(event) => selectTag(event, "untagged")}
-          className={`d-flex btn ${itemStyle.btn} justify-content-between align-items-start`}
-        >
-          untagged
-          <Badge bg="primary" pill>
-            {bookmark.fetchedBookmarks.filter((b) => b.tags.length == 0).length}
-          </Badge>
-        </button>
-      </ListGroup.Item>,
-    );
-  }
+
   tagMap.forEach((tagCnt) => {
-    groupItems.push(
-      <ListGroup.Item
-        key={`${tagCnt.title}-item`}
-        className={`${itemStyle.item}`}
-      >
-        <button
-          onClick={(event) => selectTag(event, tagCnt.title)}
-          data-testid={`${tagCnt.title}-list-item`}
-          key={`${tagCnt.title}-list-item`}
-          className={`d-flex btn ${itemStyle.btn} justify-content-between align-items-start`}
+    if (tagCnt.count > 0) {
+      groupItems.push(
+        <ListGroup.Item
+          key={`${tagCnt.title}-item`}
+          className={`${itemStyle.item}`}
         >
-          {tagCnt.title}
-          <Badge bg="primary" pill>
-            <div
-              data-testid={`${tagCnt.title}-list-item-cnt`}
-              key={`${tagCnt.title}-list-item-badge`}
-            >
-              {tagCnt.count}
-            </div>
-          </Badge>
-        </button>
-      </ListGroup.Item>,
-    );
+          <button
+            onClick={(event) => selectTag(event, tagCnt.id!)}
+            data-testid={`${tagCnt.title}-list-item`}
+            key={`${tagCnt.title}-list-item`}
+            className={`d-flex btn ${itemStyle.btn} justify-content-between align-items-start`}
+          >
+            {tagCnt.title}
+            <Badge bg="primary" pill>
+              <div
+                data-testid={`${tagCnt.title}-list-item-cnt`}
+                key={`${tagCnt.title}-list-item-badge`}
+              >
+                {tagCnt.count}
+              </div>
+            </Badge>
+          </button>
+        </ListGroup.Item>,
+      );
+    }
   });
 
   if (groupItems.length == 0) {

--- a/frontend/contexts/BookmarkContext.tsx
+++ b/frontend/contexts/BookmarkContext.tsx
@@ -24,7 +24,7 @@ export const BookmarkContext = createContext<ProviderProps>({
 });
 
 export const BookmarkDispatchContext = createContext<Dispatch<BookmarkAction>>(
-  () => {},
+  () => { },
 );
 
 export function useBookmarks() {

--- a/frontend/contexts/SelectedContext.tsx
+++ b/frontend/contexts/SelectedContext.tsx
@@ -8,13 +8,13 @@ import {
 } from "react";
 
 export interface TagProvider {
-  selected: string[];
-  setSelected: Dispatch<SetStateAction<string[]>>;
+  selected: number[];
+  setSelected: Dispatch<SetStateAction<number[]>>;
 }
 
 export const SelectedTagContext = createContext<TagProvider>({
   selected: [],
-  setSelected: () => {},
+  setSelected: () => { },
 });
 
 export function SelectedTagProvider({
@@ -22,7 +22,7 @@ export function SelectedTagProvider({
 }: {
   readonly children: React.ReactNode;
 }) {
-  const [selected, setSelected] = useState<string[]>([]);
+  const [selected, setSelected] = useState<number[]>([]);
 
   const selectedMemo = useMemo(() => ({ selected, setSelected }), [selected]);
 

--- a/frontend/contexts/TagContext.tsx
+++ b/frontend/contexts/TagContext.tsx
@@ -3,13 +3,25 @@ import TagAction from "@/types/Bookmarks/TagAction";
 import { TagWithCnt } from "@/types/Bookmarks/Tag";
 import Bookmark from "@type/Bookmarks/Bookmark";
 
+const initialTagCnts: Map<number, TagWithCnt> = new Map();
+
 export const TagsCntContext = createContext<Map<number, TagWithCnt>>(
   new Map<number, TagWithCnt>(),
 );
 export const TagsCntDispatchContext = createContext<Dispatch<TagAction>>(
-  () => {},
+  () => { },
 );
 
+/**
+ * This code looks complex and it kind of is, its layers of React gobbledygook.
+ * The short version of it is that this provider uses 
+ * TagsCntDispatchContext context and declares that anyone that uses
+ * TagsCntDispatchContext will get the provider value of dispatch. 
+ * Meaning that the tagCntReducer will be available to increment those new bookmarks for you.
+ *
+ * You might say to yourself well the TagsCntDispatchContext looks like its just a context.
+ * Yes, you're right but we then do the magic in the JSX below to wire it in.
+ */
 export function TagCntProvider({
   children,
 }: {
@@ -26,9 +38,14 @@ export function TagCntProvider({
   );
 }
 
+/**
+  * tagMap: is the initial state, in this case an empty map.
+  * action: add, delete.
+  */
 function tagCntReducer(tagMap: Map<number, TagWithCnt>, action: TagAction) {
   const tagId = action.id;
   const tagCnt: TagWithCnt | undefined = tagMap.get(action.id);
+  const untaggeds: TagWithCnt | undefined = tagMap.get(-1);
   // create a deep copy of the existing.
   const newTagMap = new Map(tagMap);
 
@@ -36,15 +53,17 @@ function tagCntReducer(tagMap: Map<number, TagWithCnt>, action: TagAction) {
 
   switch (action.type) {
     case "add": {
-      if (tagCnt) {
+      if (tagCnt !== undefined) {
         addBkmkToTag(tagCnt, action.bookmark);
         newTagMap.set(tagId, {
+          id: tagId,
           title: tagCnt.title,
           count: tagCnt.count + 1,
           associatedBkmks: tagCnt.associatedBkmks,
         });
       } else {
         newTagMap.set(tagId, {
+          id: tagId,
           title: action.title,
           count: 1,
           associatedBkmks: [bkmk],
@@ -55,11 +74,13 @@ function tagCntReducer(tagMap: Map<number, TagWithCnt>, action: TagAction) {
     case "delete": {
       if (tagCnt && tagCnt.count > 1) {
         newTagMap.set(tagId, {
+          id: tagId,
           title: tagCnt.title,
           count: tagCnt.count - 1,
           associatedBkmks: remBkmkFrmTag(tagCnt, action.bookmark),
         });
       } else {
+        // delete the tag from the map if its the last one
         newTagMap.delete(action.id);
       }
       return newTagMap;
@@ -98,4 +119,3 @@ export function useTagsDispatch() {
   return useContext(TagsCntDispatchContext);
 }
 
-const initialTagCnts: Map<number, TagWithCnt> = new Map();

--- a/frontend/types/Bookmarks/Tag.ts
+++ b/frontend/types/Bookmarks/Tag.ts
@@ -1,4 +1,5 @@
 import Bookmark from "./Bookmark";
+export const UNTAGGED = "untagged"
 
 export default interface Tag {
   id: number;
@@ -13,6 +14,7 @@ export interface TagReqPayload {
 
 // Tag with count associated bookmarks.
 export interface TagWithCnt {
+  id?: number;
   title: string;
   associatedBkmks: Bookmark[];
   count: number;


### PR DESCRIPTION
Fixes #136

---

## Checklist

- [x] Code Formatter (run prettier/spotlessApply)
- [ ] Code has unit tests? (If no explain in _other_information_)
- [x] Builds on localhost
- [x] Builds/Runs in docker compose

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?

Bookmarks created without tags are not grouped under any tag.

## What is the new behavior?

Treat bookmarks with no tags as if they belong to a special “untagged” tag, that way they can be listed, counted and filtered like any other tag.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
